### PR TITLE
fix error on empty message

### DIFF
--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -295,15 +295,15 @@ func (c *clientStream) RecvMsg(m interface{}) error {
 		}
 		return c.ctx.Err()
 	case bytes, ok := <-c.recvRead:
-		if ok && bytes != nil {
-			if frame, ok := m.(*Frame); ok {
-				frame.Payload = bytes
-				return nil
-			} else {
-				return proto.Unmarshal(bytes, m.(proto.Message))
-			}
+		if !ok {
+			return io.EOF
 		}
-		return io.EOF
+
+		if frame, ok := m.(*Frame); ok {
+			frame.Payload = bytes
+			return nil
+		}
+		return proto.Unmarshal(bytes, m.(proto.Message))
 	}
 }
 

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -329,9 +329,9 @@ func (s *serverStream) processEnd(end *nrpc.End) {
 		s.done()
 	} else {
 		s.muWrite.Lock()
-		defer  s.muWrite.Unlock()
+		defer s.muWrite.Unlock()
 		s.log.Info("closeSend")
-		if s.recvWrite !=nil {
+		if s.recvWrite != nil {
 			s.recvWrite <- nil
 			close(s.recvWrite)
 			s.recvWrite = nil
@@ -434,10 +434,10 @@ func (s *serverStream) RecvMsg(m interface{}) error {
 	case <-s.ctx.Done():
 		return s.ctx.Err()
 	case bytes, ok := <-s.recvRead:
-		if ok && bytes != nil {
-			return proto.Unmarshal(bytes, m.(proto.Message))
+		if !ok {
+			return io.EOF
 		}
-		return io.EOF
+		return proto.Unmarshal(bytes, m.(proto.Message))
 	}
 }
 


### PR DESCRIPTION
Given the following request message:

```proto
message GetUsersRequest {
  repeated string user_ids = 1;
  repeated string fields = 2;
}
```

Calling it on the client with both fields set to nil (see below) will result in an EOF without ever calling the handler function.

```go
users, err := cl.GetUsers(ctx, &dbproto.GetUsersRequest{})
```

Providing an empty request message (no fields filled) is a valid request.
